### PR TITLE
Removed unnecessary galaxy from install script

### DIFF
--- a/install/install.pl
+++ b/install/install.pl
@@ -4,9 +4,7 @@ use FindBin;
 use strict;
 use warnings;
 
-use constant DEFAULT_REST_URL=>"http://ngs-archive.corefacility.ca/irida-api";
-use constant DEFAULT_GALAXY_URL=>"http://galaxy.corefacility.ca/";
-use constant DEFAULT_GALAXY_APIKEY=>"None";
+use constant DEFAULT_REST_URL=>"http://localhost:8080/api";
 
 
 #Install PERL packages
@@ -55,20 +53,6 @@ if($ret eq "y"){
 	print "Setting base URL as $ngsloc in $confFile\n";
         print OUT "[apiurls]\n";
 	print OUT "BASEURL=$ngsloc\n";
-
-        my $galaxyurl = textOption("Galaxy URL location?",DEFAULT_GALAXY_URL);
-	print "Setting Galaxy URL as $galaxyurl in $confFile\n";
-	print OUT "GALAXYURL=$galaxyurl\n";
-
-        my $galaxyapikey = textOption("Galaxy api key?",DEFAULT_GALAXY_APIKEY);
-	print "Setting Galaxy URL as $galaxyapikey in $confFile\n";
-        print OUT "[credentials]\n";
-        if ( $galaxyapikey eq 'None') {
-            print OUT "#GALAXYAPIKEY=VALUE\n";
-        }
-        else {
-            print OUT "GALAXYAPIKEY=$galaxyapikey\n";            
-        }
 
         
 	close OUT;


### PR DESCRIPTION
Removed the unnecessary galaxy stuff from the linker install script.  The script was borrowed from an old galaxy tool so it had that stuff in there that it didn't need.

Also changed the default REST url to localhost since the other default didn't make sense for anyone else.