### PR TITLE
Updated version to 1.1.1 so script version matches git tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ CHANGES
 1.1
 ---
 * Added ability to link and download assemblies.  This is done with the `-t` option.  Default is `fastq`, if you choose `-t assembly` it will link the assemblies for the sample.  You can do both file types with `-t fastq,assembly`.
+* Updated version in ngsArchiveLinker.pl script to match git tag (1.1.1).

--- a/ngsArchiveLinker.pl
+++ b/ngsArchiveLinker.pl
@@ -22,7 +22,7 @@ if ( !@ARGV ) {    #if no args, print usage message
     pod2usage(0);
 }
 
-my $version       = '1.0.2';
+my $version       = '1.1.1';
 my $print_version = 0;
 
 my $client_id     = "defaultLinker";


### PR DESCRIPTION
Updated version to 1.1.1 inside the ngsArchiveLinker.pl script.  Previously this was accidentally left as 1.0.2 even though the git tag was updated to 1.1.