### PR TITLE
OAuth2 Compatibility Update

### DIFF
--- a/ngsArchiveLinker.pl
+++ b/ngsArchiveLinker.pl
@@ -238,8 +238,11 @@ sub getToken {
 
     if ( !defined $tokenstr ) {
         print "Couldn't get OAuth token: " . $response->{'status'} . "\n";
-        print $oauth_info->{'error'} . ': '
-          . $oauth_info->{'error_description'} . "\n";
+        print $oauth_info->{'error'};
+        if (exists($oauth_info->{'error_description'})) {
+            print ': ' . $oauth_info->{'error_description'};
+        }
+        print "\n";
         exit(1);
     }
 


### PR DESCRIPTION
Updates OAuth2 error handling to check for `error_description` in response before attempting to display it as it may not be present in IRIDA 22.09 and higher.